### PR TITLE
增加sshpass组件，不需要强制配置ssh免密

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,5 @@ RUN set -x \
     && ln -s /usr/bin/python3 /usr/libexec/platform-python \
       # Cleaning
     && rm -rf ./"$KUBEASZ_VER".tar.gz
+RUN apt add sshpass \
+    && apt cache clean 


### PR DESCRIPTION
增加ansible inventory文件中使用SSH账号密码进行配置，不需要配置ssh免密。
/etc/kubeasz/clusters/xxx/hosts

```yaml
......
# s所有主机密码一直可以使用all变量
[all:vars]
ansible_ssh_user=root
ansible_ssh_pass="123456"

# 如果账号密码不一样的话，可以分开写
[kube_node]
192.168.1.1 ansible_ssh_user="root" ansible_ssh_pass="123456"
192.168.1.2 ansible_ssh_user="root" ansible_ssh_pass="654321"
```

同时检查/etc/kubeasz/ansible.cfg，下面的配置必须保证为`False`
```yaml
host_key_checking = False
```