### PR TITLE
build: 添加 sshpass 到 Docker 镜像

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ RUN set -x \
     && ln -s -f /usr/local/bin/python3.11 /usr/bin/python3 \
     && mkdir -p /usr/libexec \
     && ln -s /usr/bin/python3 /usr/libexec/platform-python \
+    && apk add sshpass \
     # Cleaning
     && rm -rf ./"$KUBEASZ_VER".tar.gz


### PR DESCRIPTION
安装sshpass，解决用户未配置免密，而是使用密码登录的场景需求